### PR TITLE
EDGNCIP-18: Vert.x 4.3.4 fixing XXE and HTTP Request Smuggling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 		</license>
 	</licenses>
 	<properties>
-		<vertx.version>4.1.1</vertx.version>
+		<vertx.version>4.3.4</vertx.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>11</java.version>
@@ -30,7 +30,7 @@
 			<dependency>
          <groupId>org.apache.logging.log4j</groupId>
          <artifactId>log4j-bom</artifactId>
-         <version>2.17.0</version>
+         <version>2.17.2</version>
          <type>pom</type>
          <scope>import</scope>
      		</dependency>
@@ -53,12 +53,10 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-annotations</artifactId>
-			<version>2.9.4</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.dataformat</groupId>
 			<artifactId>jackson-dataformat-xml</artifactId>
-			<version>2.9.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.folio</groupId>
@@ -73,7 +71,6 @@
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-api</artifactId>
-			<version>2.17.1</version>
 		</dependency>
 	</dependencies>
 	<repositories>


### PR DESCRIPTION
Upgrade Vert.x from 4.1.1 to 4.3.4.

Upgrading Vert.x indirectly upgrades jackson-databind fixing Stack Overflow Denial of Service (DoS): https://nvd.nist.gov/vuln/detail/CVE-2020-36518

Upgrading Vert.x indirectly upgrades com.fasterxml.woodstox:woodstox-core fixing XML External Entity (XXE) Injection: https://app.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLWOODSTOX-2928754

Upgrading Vert.x indirectly upgrades Netty fixing HTTP Request Smuggling: https://nvd.nist.gov/vuln/detail/CVE-2021-43797