### PR TITLE
bump up edge-common to v4.7.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
 		<dependency>
 			<groupId>org.folio</groupId>
 			<artifactId>edge-common</artifactId>
-			<version>4.7.0</version>
+			<version>4.7.1</version>
 		</dependency>
 		<dependency>
 			<groupId>args4j</groupId>


### PR DESCRIPTION
bump up edge-common to v4.7.1: AwsParamStore to support FIPS-approved crypto modules