### PR TITLE
EDGNCIP-29 - V1.10.1 Temp

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+## 1.10.0 2024-07-03
+ * [EDGNCIP-29](https://folio-org.atlassian.net/browse/EDGNCIP-29) edge-common 4.7.1: AwsParamStore to support FIPS-approved crypto modules
 ## 1.10.0 2024-05-29
  * [EDGNCIP-26](https://folio-org.atlassian.net/browse/EDGNCIP-26) Enhance WebClient TLS Configuration for Secure Connections to OKAPI
  * [EDGNCIP-27](https://folio-org.atlassian.net/browse/EDGNCIP-27) Enhance HTTP Endpoint Security with TLS and FIPS-140-2 Compliant Cryptography

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-## 1.10.0 2024-07-03
+## 1.10.1 2024-07-03
  * [EDGNCIP-29](https://folio-org.atlassian.net/browse/EDGNCIP-29) edge-common 4.7.1: AwsParamStore to support FIPS-approved crypto modules
 ## 1.10.0 2024-05-29
  * [EDGNCIP-26](https://folio-org.atlassian.net/browse/EDGNCIP-26) Enhance WebClient TLS Configuration for Secure Connections to OKAPI

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.folio</groupId>
 	<artifactId>edge-ncip</artifactId>
-	<version>1.10.1</version>
+	<version>1.10.2-SNAPSHOT</version>
 	<name>Edge API - NCIP</name>
 	<description>NCIP responder for FOLIO (edge module)</description>
 	<licenses>
@@ -143,7 +143,7 @@
 		<url>https://github.com/folio-org/edge-ncip</url>
 		<connection>scm:git:git://github.com/folio-org/edge-ncip</connection>
 		<developerConnection>scm:git:git@github.com:folio-org/edge-ncip.git</developerConnection>
-		<tag>v1.10.1</tag>
+		<tag>HEAD</tag>
 	</scm>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
 		<dependency>
 			<groupId>org.folio</groupId>
 			<artifactId>edge-common</artifactId>
-			<version>4.7.0</version>
+			<version>4.7.1</version>
 		</dependency>
 		<dependency>
 			<groupId>args4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.folio</groupId>
 	<artifactId>edge-ncip</artifactId>
-	<version>1.10.1-SNAPSHOT</version>
+	<version>1.10.1</version>
 	<name>Edge API - NCIP</name>
 	<description>NCIP responder for FOLIO (edge module)</description>
 	<licenses>
@@ -143,7 +143,7 @@
 		<url>https://github.com/folio-org/edge-ncip</url>
 		<connection>scm:git:git://github.com/folio-org/edge-ncip</connection>
 		<developerConnection>scm:git:git@github.com:folio-org/edge-ncip.git</developerConnection>
-		<tag>HEAD</tag>
+		<tag>v1.10.1</tag>
 	</scm>
 
 	<build>


### PR DESCRIPTION
[EDGNCIP-29](https://folio-org.atlassian.net/browse/EDGNCIP-29) edge-common 4.7.1: AwsParamStore to support FIPS-approved crypto modules