### PR TITLE
EDGNCIP-42

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+## 1.11.2 2026-07-07
+ * [EDGNCIP-42](https://folio-org.atlassian.net/browse/EDGNCIP-42) edge-ncip v1.11.1 deploys on Trillium TLS BugFest cluster but all tests fail with HTTP 500 errors
 ## 1.11.1 2026-06-02
  * [EDGNCIP-38](https://folio-org.atlassian.net/browse/EDGNCIP-38) Use GitHub Workflows for Maven
 ## 1.11.0 2026-04-10

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>21</java.version>
+		<commons-lang3.version>3.17.0</commons-lang3.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>
@@ -81,6 +82,11 @@
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-api</artifactId>
 		</dependency>
+		<dependency>
+    		<groupId>org.apache.commons</groupId>
+    		<artifactId>commons-lang3</artifactId>
+    		<version>${commons-lang3.version}</version>
+  		</dependency>
 		<!-- Test dependencies -->
 		<dependency>
 			<groupId>org.hamcrest</groupId>


### PR DESCRIPTION
[EDGNCIP-42](https://folio-org.atlassian.net/browse/EDGNCIP-42): edge-ncip v1.11.1 deploys on Trillium TLS BugFest cluster but all tests fail with HTTP 500 errors

