### PR TITLE
Update edge-common dependency version to 5.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
 		<dependency>
 			<groupId>org.folio</groupId>
 			<artifactId>edge-common</artifactId>
-			<version>5.0.0</version>
+			<version>5.1.1</version>
 		</dependency>
 		<dependency>
 			<groupId>args4j</groupId>


### PR DESCRIPTION
The edge-common version was updated to the Trillium tag - 5.1.x. - as a part of the update for this jira: https://folio-org.atlassian.net/browse/EDGNCIP-42